### PR TITLE
Remove a program from its context when it goes out of scope.

### DIFF
--- a/Code/src/ocl_program.cpp
+++ b/Code/src/ocl_program.cpp
@@ -165,7 +165,10 @@ ocl::Program::~Program()
 */
 void ocl::Program::release()
 {
-    if(this->isBuilt()){
+    if(_context)
+        _context->release(this);
+
+   if(this->isBuilt()){
         removeKernels();
         OPENCL_SAFE_CALL( clReleaseProgram (_id));
 


### PR DESCRIPTION
This prevents a crash where the Program goes out of scope, but
the context tries to free it, anyway:

Program received signal SIGSEGV, Segmentation fault.
0x000000000042a76f in ocl::Program::removeKernels() ()
(gdb) bt
0  0x000000000042a76f in ocl::Program::removeKernels() ()
1  0x000000000042a645 in ocl::Program::release() ()
2  0x000000000040de5b in ocl::Context::release(ocl::Program*) ()
3  0x000000000040d1e7 in ocl::Context::release() ()
4  0x000000000040d0a3 in ocl::Context::~Context() ()
5  0x0000000000406b9f in main () at main.cpp:30
(program already went out of block)
