### PR TITLE
Changing placement of pragma cl_khr_fp64

### DIFF
--- a/Code/src/ocl_kernel.cpp
+++ b/Code/src/ocl_kernel.cpp
@@ -612,7 +612,7 @@ std::string ocl::Kernel::specialize(const std::string& kernel, const std::string
     fct.erase(start, end - start + 2);
 
 // #if defined OPENCL_V1_1 || defined OPENCL_V1_0
-	if(type == "double") fct.insert(0, "#if !defined(__OPENCL_VERSION__) || __OPENCL_VERSION__ < 120\n#pragma OPENCL EXTENSION cl_khr_fp64: enable\n#endif\n");
+//	if(type == "double") fct.insert(0, "#if !defined(__OPENCL_VERSION__) || __OPENCL_VERSION__ < 120\n#pragma OPENCL EXTENSION cl_khr_fp64: enable\n#endif\n");
 // #endif
 
 

--- a/Code/src/ocl_program.cpp
+++ b/Code/src/ocl_program.cpp
@@ -389,7 +389,20 @@ ocl::Program& ocl::Program::operator << (const std::string &k)
 //     commonCodeBlocks_.resize( 0 );
 //   }
   
-    std::string kernels = k;
+    std::string kernels;
+    
+    {
+      auto const doubleTypeIter = std::find_if( _types.begin(), _types.end(), []( utl::Type const* t ){
+        return *t == utl::type::Double;
+      } );
+      
+      
+      if ( doubleTypeIter != _types.end() ) {
+        kernels = "#if !defined(__OPENCL_VERSION__) || __OPENCL_VERSION__ < 120\n#pragma OPENCL EXTENSION cl_khr_fp64: enable\n#endif\n" + k;
+      } else {
+        kernels = k;
+      }
+    }
 #if 0 // For now disable comment removal as we need it to play a trick on the AMD compiler.
     eraseComments(kernels);
 #endif


### PR DESCRIPTION
Enabling double support for pre CL1.2 devices on a per file and not per kernel basis